### PR TITLE
Allow ignorePaths as a plugin option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import fastGlob from 'fast-glob';
 import { Plugin } from 'esbuild';
 
-const EsbuildPluginImportGlob = (): Plugin => ({
+interface Config {
+  ignorePaths: string[];
+}
+
+const EsbuildPluginImportGlob = (config?: Config): Plugin => ({
   name: 'require-context',
   setup: (build) => {
     build.onResolve({ filter: /\*/ }, async (args) => {
@@ -22,6 +26,7 @@ const EsbuildPluginImportGlob = (): Plugin => ({
       const files = (
         await fastGlob(args.path, {
           cwd: args.pluginData.resolveDir,
+          ignore: config?.ignorePaths ?? [],
         })
       ).sort();
 


### PR DESCRIPTION
Exposes some basic config options to the plugin, for now allowing you to specifically expose a set of paths you wish to ignore from your glob match